### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/secret-sync.yml
+++ b/.github/workflows/secret-sync.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Secrets Sync Action
-      uses: google/secrets-sync-action@v1.7.1
+      uses: jpoehnelt/secrets-sync-action@v1.7.1
       with:
         github_token: ${{ secrets.RSG_SYNC_TOKEN }}
         repositories: |


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.